### PR TITLE
Avoid importing math library

### DIFF
--- a/changesetmd.py
+++ b/changesetmd.py
@@ -19,7 +19,6 @@ from lxml import etree
 from datetime import datetime
 from datetime import timedelta
 from io import StringIO
-import math
 try:
     from bz2file import BZ2File
     bz2Support = True
@@ -139,10 +138,8 @@ class ChangesetMD():
         print ("parsed {:,}".format(parsedCount))
 
     def fetchReplicationFile(self, sequenceNumber):
-        topdir = '{:>03}'.format(str(math.floor(sequenceNumber / 1000000))) #format(sequenceNumber / 1000000, '000')
-        subdir = '{:>03}'.format(str(math.floor((sequenceNumber / 1000) % 1000))) # format((sequenceNumber / 1000) % 1000, '000')
-        fileNumber = '{:>03}'.format(str(sequenceNumber % 1000)) # format(sequenceNumber % 1000, '000')
-        fileUrl = BASE_REPL_URL + topdir + '/' + subdir + '/' + fileNumber + '.osm.gz'
+        _seq_ascii = f"{str(sequenceNumber):0>09}"
+        fileUrl = BASE_REPL_URL + _seq_ascii[0:3] + '/' + _seq_ascii[3:6] + '/' + _seq_ascii[6:] + '.osc.gz'
         print ("opening replication file at " + fileUrl)
         
         try:

--- a/osmh.py
+++ b/osmh.py
@@ -19,7 +19,6 @@ from lxml import etree
 from datetime import datetime
 from datetime import timedelta
 from io import StringIO
-import math
 try:
     from bz2file import BZ2File
     bz2Support = True
@@ -536,10 +535,8 @@ class osmh():
         print ("parsed {:,}".format(parsedElements),'Ended on: ',datetime.now())
 
     def fetchReplicationFile(self, sequenceNumber):
-        topdir = '{:>03}'.format(str(math.floor(sequenceNumber / 1000000))) #format(sequenceNumber / 1000000, '000')
-        subdir = '{:>03}'.format(str(math.floor((sequenceNumber / 1000) % 1000))) # format((sequenceNumber / 1000) % 1000, '000')
-        fileNumber = '{:>03}'.format(str(sequenceNumber % 1000)) # format(sequenceNumber % 1000, '000')
-        fileUrl = BASE_REPL_URL + topdir + '/' + subdir + '/' + fileNumber + '.osc.gz'
+        _seq_ascii = f"{str(sequenceNumber):0>09}"
+        fileUrl = BASE_REPL_URL + _seq_ascii[0:3] + '/' + _seq_ascii[3:6] + '/' + _seq_ascii[6:] + '.osc.gz'
         print ("opening replication file at " + fileUrl)
         
         try:

--- a/updater.py
+++ b/updater.py
@@ -19,7 +19,7 @@ from lxml import etree
 from datetime import datetime
 from datetime import timedelta
 from io import StringIO
-import math
+#import math
 
 try:
     from bz2file import BZ2File


### PR DESCRIPTION
Use string split to deal with how URL are generated from change
sequence numbers and avoid importing the large math library
altogether.

sequence numbers need to be zero padded on the left and the resulting
string split into three digits separated by forward slash to form the
download url path.